### PR TITLE
Specify memory limit

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,22 +1,24 @@
 #!/usr/bin/env node
-'use strict'
-const meow = require('meow')
-const killFirefox = require('.')
+"use strict";
+const meow = require("meow");
+const killFirefox = require(".");
 
 const cli = meow(
   `
   Usage
     $ kill-firefox-tabs
+
+    $ kill-firefox-tabs -m 250
 `,
   {
     flags: {
       memory: {
-        type: 'number',
+        type: "number",
         default: 200,
-        alias: 'm',
+        alias: "m",
       },
     },
   }
-)
+);
 
-killFirefox(cli.flags)
+killFirefox(cli.flags);

--- a/cli.js
+++ b/cli.js
@@ -1,13 +1,22 @@
 #!/usr/bin/env node
-'use strict';
-const meow = require('meow');
-const killFirefox = require('.');
+'use strict'
+const meow = require('meow')
+const killFirefox = require('.')
 
-const cli = meow(`
+const cli = meow(
+  `
   Usage
     $ kill-firefox-tabs
-`, {
-  flags: null
-});
+`,
+  {
+    flags: {
+      memory: {
+        type: 'number',
+        default: 200,
+        alias: 'm',
+      },
+    },
+  }
+)
 
-killFirefox(cli.flags);
+killFirefox(cli.flags)

--- a/index.js
+++ b/index.js
@@ -1,16 +1,16 @@
-'use strict'
-const fkill = require('fkill')
-const psList = require('ps-list')
+"use strict";
+const fkill = require("fkill");
+const psList = require("ps-list");
 
 module.exports = async (options = {}) => {
-  const list = await psList()
+  const list = await psList();
 
   const processes = {
-    firefox: process.platform === 'darwin' ? 'Firefox' : 'firefox',
-  }
+    firefox: process.platform === "darwin" ? "Firefox" : "firefox",
+  };
 
   const kill_limit =
-    parseInt(options.memory) > 50 ? parseInt(options.memory) / 100 : 0.2
+    parseInt(options.memory) > 50 ? parseInt(options.memory) / 100 : 0.2;
 
   const pids = list
     .filter(
@@ -18,9 +18,9 @@ module.exports = async (options = {}) => {
         Object.keys(processes).some((name) =>
           x.cmd.includes(processes[name])
         ) &&
-        x.cmd.includes('-childID') &&
+        x.cmd.includes("-childID") &&
         x.memory > kill_limit
     )
-    .map((x) => x.pid)
-  return fkill(pids, { force: true })
-}
+    .map((x) => x.pid);
+  return fkill(pids, { force: true });
+};

--- a/index.js
+++ b/index.js
@@ -1,19 +1,26 @@
-'use strict';
-const fkill = require('fkill');
-const psList = require('ps-list');
+'use strict'
+const fkill = require('fkill')
+const psList = require('ps-list')
 
 module.exports = async (options = {}) => {
-  const list = await psList();
+  const list = await psList()
 
   const processes = {
-    firefox: process.platform === 'darwin' ? 'Firefox' : 'firefox'
-  };
+    firefox: process.platform === 'darwin' ? 'Firefox' : 'firefox',
+  }
+
+  const kill_limit =
+    parseInt(options.memory) > 50 ? parseInt(options.memory) / 100 : 0.2
 
   const pids = list
-    .filter(x =>
-      Object.keys(processes).some(name => x.cmd.includes(processes[name])) &&
-      x.cmd.includes('-childID')
+    .filter(
+      (x) =>
+        Object.keys(processes).some((name) =>
+          x.cmd.includes(processes[name])
+        ) &&
+        x.cmd.includes('-childID') &&
+        x.memory > kill_limit
     )
-    .map(x => x.pid);
-  return fkill(pids, {force: true});
-};
+    .map((x) => x.pid)
+  return fkill(pids, { force: true })
+}


### PR DESCRIPTION
This branch allows you to specify the max memory that a tab can use, for example:

```
kill-firefox-tabs -m 250
```
or by default tabs consuming more than 200 Mbs